### PR TITLE
Typos: add missing 'the' to GDS attorney start page & replace ref no with access code

### DIFF
--- a/app/views/register-lasting-power-of-attorney/attorney.html
+++ b/app/views/register-lasting-power-of-attorney/attorney.html
@@ -147,7 +147,7 @@ Register a lasting power of attorney: Agree to be an attorney
 
  <p>If you've not used GOV.UK One Login before, you'll be asked to set up an account.</p>
 
- <p>You’ll also need the LPA reference number. This will be in the letter or email you received telling you about the LPA.</p>
+ <p>You’ll also need your attorney access code. This will be in the letter or email you received telling you about the LPA.</p>
 
  <p>You can save your progress and <a href="{{ data['mrlpa_service_url'] }}/attorney-login">return to the LPA</a> at a later date if you need to.</p>
 

--- a/app/views/register-lasting-power-of-attorney/attorney.html
+++ b/app/views/register-lasting-power-of-attorney/attorney.html
@@ -103,7 +103,7 @@ Register a lasting power of attorney: Agree to be an attorney
       <p>You must:</p>
    <ul class="govuk-list govuk-list--bullet">
 	   <li>be aged 18 or older</li>
-    <li>act as instructed by donor in the LPA</li>
+    <li>act as instructed by the donor in the LPA</li>
      <li>support the donor to make their own decisions wherever possible</li>
      <li>act in the donor’s best interests</li>
      <li>keep the donor's money and property separate from your own (unless you already share a bank account)</li>


### PR DESCRIPTION
Typo: add missing 'the' to GDS attorney start page (second bullet on page)